### PR TITLE
Add filtering for the Borrowings List endpoint

### DIFF
--- a/borrowings/permissions.py
+++ b/borrowings/permissions.py
@@ -4,3 +4,9 @@ from rest_framework.permissions import SAFE_METHODS, BasePermission
 class IsBorrowingOwner(BasePermission):
     def has_object_permission(self, request, view, obj):
         return request.user == obj.user
+
+class IsAdminOrIsAuthenticatedOnlyCreate(BasePermission):
+    def has_permission(self, request, view):
+        if request.user and request.user.is_authenticated:
+            return request.user.is_staff or request.method in SAFE_METHODS or request.method == "POST"
+        return False


### PR DESCRIPTION
Make sure each non-admin can see only their own borrowings

Make sure borrowings are available only for authenticated users

Add the `is_active` parameter for filtering by active borrowings (not returned yet)

Add the `user_id` parameter for admin users, so admin can see all users’ borrowings, if not specified, but if specified - only for concrete user